### PR TITLE
[Feature] Adding Notes to the Customer Show Page

### DIFF
--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -7,6 +7,8 @@ class CustomersController < ApplicationController
 
   def show
     authorize @customer
+
+    @notes = @customer.notes.order(created_at: :desc).page(params[:page])
   end
 
   def new

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,0 +1,78 @@
+class NotesController < ApplicationController
+  before_action :set_customer
+  before_action :set_note, only: %i[show edit update destroy]
+
+  skip_before_action :verify_authenticity_token, only: [:create, :update, :destroy]
+
+  def show
+    authorize @note
+  end
+
+  def new
+    @note = @customer.notes.build
+    authorize @note
+  end
+
+  def edit; end
+
+  def create
+    @note = @customer.notes.build(note_params)
+    @note.user = current_user
+
+    authorize @note
+
+    if @note.save
+      render json: {
+        success: true,
+        note: {
+          id: @note.id,
+          content: @note.content,
+          user_email: @note.user.email,
+          created_at: @note.created_at,
+        }
+      }
+    else
+      render json: { success: false, errors: @note.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    authorize @note
+
+    if @note.update_attribute(:content, params[:note][:content])
+      render json: {
+        success: true,
+        note: {
+          id: @note.id,
+          content: @note.content,
+          user_email: @note.user.email,
+          created_at: @note.created_at
+        }
+      }
+    else
+      render json: { success: false, errors: ["Failed to update note"] }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    authorize @note
+
+    @note.destroy
+
+    render json: { success: true }
+  end
+
+  private
+
+  def set_customer
+    @customer = Customer.find(params[:customer_id])
+  end
+
+  def set_note
+    @note = Note.find(params[:id])
+  end
+
+  def note_params
+    params.require(:note).permit(:content)
+  end
+end

--- a/app/javascript/controllers/expandable_notes_controller.js
+++ b/app/javascript/controllers/expandable_notes_controller.js
@@ -1,0 +1,226 @@
+import { Controller } from "@hotwired/stimulus"
+
+let currentEditingNoteId = null;
+
+export default class extends Controller {
+  static values = {
+    customerId: Number,
+    userId: Number
+  }
+
+  static targets = [
+    "form",
+    "input",
+    "showFormButton",
+    "notesList",
+    "emptyMessage"
+  ]
+
+  connect() {
+    window.expandableNotesController = this;
+  }
+
+  toggleForm(event) {
+    // Toggle form visibility
+    this.formTarget.classList.toggle('show');
+
+    // Toggle button visibility
+    this.showFormButtonTarget.classList.toggle('d-none');
+
+    // Clear input when hiding form
+    if (!this.formTarget.classList.contains('show')) {
+      this.inputTarget.value = '';
+    }
+  }
+
+  addNote(event) {
+    const content = this.inputTarget.value;
+
+    if (!content.trim()) {
+      alert("Note cannot be empty!");
+      return;
+    }
+
+    // Clear input
+    this.inputTarget.value = '';
+
+    // Hide form and show button
+    this.formTarget.classList.remove('show');
+    this.showFormButtonTarget.classList.remove('d-none');
+
+    fetch(`/customers/${this.customerIdValue}/notes`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': this.getCSRFToken()
+      },
+      body: JSON.stringify({
+        note: {
+          content: content
+        }
+      })
+    })
+    .then(response => {
+      if (!response.ok) {
+        throw new Error('Network response was not ok');
+      }
+      return response.json();
+    })
+    .then(data => {
+      if (data.success) {
+        this.appendNoteToList(data.note);
+
+        // Remove "No notes yet" message if it exists
+        if (this.hasEmptyMessageTarget) {
+          this.emptyMessageTarget.remove();
+        }
+      } else {
+        alert("Failed to create note!");
+      }
+    })
+    .catch(error => {
+      console.error('Error:', error);
+      alert("An error occurred while saving the note!");
+    });
+  }
+
+  editNote(noteId, content) {
+    // Get note element
+    const noteElement = document.getElementById(`note-${noteId}`);
+    const noteBody = noteElement.querySelector('.card-body');
+
+    // Set current editing note
+    currentEditingNoteId = noteId;
+
+    // Replace note content with edit form
+    noteBody.innerHTML = `
+      <textarea class="form-control" id="edit-note-${noteId}" rows="3">${content}</textarea>
+      <div class="mt-2">
+        <button onclick="window.expandableNotesController.saveEdit()" class="btn btn-sm btn-success">Save</button>
+        <button onclick="window.expandableNotesController.cancelEdit(${noteId}, '${content.replace(/'/g, "\\'")}')" class="btn btn-sm btn-secondary">Cancel</button>
+      </div>
+    `;
+  }
+
+  saveEdit() {
+    if (!currentEditingNoteId) return;
+
+    const content = document.getElementById(`edit-note-${currentEditingNoteId}`).value;
+
+    if (!content.trim()) {
+      alert("Note cannot be empty!");
+      return;
+    }
+
+    fetch(`/customers/${this.customerIdValue}/notes/${currentEditingNoteId}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': this.getCSRFToken()
+      },
+      body: JSON.stringify({
+        note: {
+          content: content
+        }
+      })
+    })
+    .then(response => {
+      if (!response.ok) {
+        throw new Error('Network response was not ok');
+      }
+      return response.json();
+    })
+    .then(data => {
+      if (data.success) {
+        const noteElement = document.getElementById(`note-${currentEditingNoteId}`);
+        const noteBody = noteElement.querySelector('.card-body');
+
+        noteBody.innerHTML = data.note.content;
+        currentEditingNoteId = null;
+      } else {
+        alert("Failed to update note!");
+      }
+    })
+    .catch(error => {
+      console.error('Error:', error);
+      alert("An error occurred while updating the note!");
+    });
+  }
+
+  cancelEdit(noteId, content) {
+    const noteElement = document.getElementById(`note-${noteId}`);
+    const noteBody = noteElement.querySelector('.card-body');
+
+    // Restore original content
+    noteBody.innerHTML = content;
+    currentEditingNoteId = null;
+  }
+
+  deleteNote(noteId) {
+    fetch(`/customers/${this.customerIdValue}/notes/${noteId}`, {
+      method: 'DELETE',
+      headers: {
+        'X-CSRF-Token': this.getCSRFToken()
+      }
+    })
+    .then(response => {
+      if (!response.ok) {
+        throw new Error('Network response was not ok');
+      }
+      return response.json();
+    })
+    .then(data => {
+      if (data.success) {
+        // Remove note from DOM
+        const noteElement = document.getElementById(`note-${noteId}`);
+        noteElement.remove();
+
+        // Check if there are any notes left
+        if (this.notesListTarget.querySelectorAll('.note-item').length === 0) {
+          // Add "No notes yet" message
+          const emptyMessage = document.createElement('p');
+          emptyMessage.className = 'text-muted';
+          emptyMessage.textContent = 'No notes yet.';
+          emptyMessage.dataset.expandableNotesTarget = 'emptyMessage';
+          this.notesListTarget.appendChild(emptyMessage);
+        }
+      } else {
+        alert("Failed to delete note!");
+      }
+    })
+    .catch(error => {
+      console.error('Error:', error);
+      alert("An error occurred while deleting the note!");
+    });
+  }
+
+  // Helper to append new note to the list
+  appendNoteToList(note) {
+    const noteHtml = `
+      <div class="card mb-3 note-item" id="note-${note.id}">
+        <div class="card-body">
+          ${note.content}
+        </div>
+        <div class="card-footer bg-transparent d-flex justify-content-between align-items-center">
+          <small class="text-muted">
+            By ${note.user_email} on ${new Date(note.created_at).toLocaleString()}
+          </small>
+          <div>
+            <button onclick="window.expandableNotesController.editNote('${note.id}', '${note.content.replace(/'/g, "\\'")}')" class="btn btn-sm btn-warning">Edit</button>
+            <button onclick="window.expandableNotesController.deleteNote('${note.id}')" class="btn btn-sm btn-danger">Delete</button>
+          </div>
+        </div>
+      </div>
+    `;
+
+    // Insert at the beginning of the list
+    const tempDiv = document.createElement('div');
+    tempDiv.innerHTML = noteHtml;
+    this.notesListTarget.prepend(tempDiv.firstElementChild);
+  }
+
+  // Helper to get CSRF token
+  getCSRFToken() {
+    return document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+  }
+}

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,0 +1,9 @@
+class Note < ApplicationRecord
+  belongs_to :user
+  belongs_to :customer
+
+  validates :content, presence: true
+
+  scope :created_by_user, ->(user_id) { where(user_id: user_id) }
+  scope :last_7_days, ->(date) { where('created_at > ? AND created_at < ?', date - 7.days.ago, date) }
+end

--- a/app/policies/note_policy.rb
+++ b/app/policies/note_policy.rb
@@ -1,0 +1,27 @@
+class NotePolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    true
+  end
+
+  def update?
+    true
+  end
+
+  def destroy?
+    true
+  end
+
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/views/customers/show.html.erb
+++ b/app/views/customers/show.html.erb
@@ -21,15 +21,76 @@
       </div>
     </div>
   </div>
-  
+
   <div class="col-md-6 mb-4">
     <div class="card">
       <div class="card-header d-flex justify-content-between align-items-center">
         <h5 class="card-title mb-0">Notes</h5>
       </div>
-      <div class="card-body">
-        <p class="text-muted">No notes yet.</p>
+
+      <div class="card-body" data-controller="expandable-notes" data-expandable-notes-customer-id-value="<%= @customer.id %>" data-expandable-notes-user-id-value="<%= current_user.id %>">
+        <div class="mb-4 collapse" data-expandable-notes-target="form">
+          <div class="p-3 border rounded">
+            <div class="mb-2">
+              <textarea data-expandable-notes-target="input" class="form-control" rows="2" placeholder="Write a note..."></textarea>
+            </div>
+            <div class="d-flex justify-content-between">
+              <button data-action="click->expandable-notes#addNote" class="btn btn-primary">Add Note</button>
+              <button data-action="click->expandable-notes#toggleForm" class="btn btn-outline-secondary">Cancel</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="mb-3">
+          <button data-action="click->expandable-notes#toggleForm" class="btn btn-primary w-100" data-expandable-notes-target="showFormButton">
+            <i class="bi bi-plus-circle me-1"></i> Add New Note
+          </button>
+        </div>
+
+        <div data-expandable-notes-target="notesList">
+          <% if @customer.notes.any? %>
+            <% @notes.each do |note| %>
+              <div class="card mb-3 note-item" id="note-<%= note.id %>">
+                <div class="card-body">
+                  <%= note.content %>
+                </div>
+                <div class="card-footer bg-transparent d-flex justify-content-between align-items-center">
+                  <small class="text-muted">
+                    By <%= note.user.email %> on <%= note.created_at.strftime("%b %d, %Y %H:%M") %>
+                  </small>
+                  <div>
+                    <button onclick="window.expandableNotesController.editNote('<%= note.id %>', '<%= escape_javascript(note.content) %>')" class="btn btn-sm btn-warning">Edit</button>
+                    <button onclick="window.expandableNotesController.deleteNote('<%= note.id %>')" class="btn btn-sm btn-danger">Delete</button>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          <% else %>
+            <p class="text-muted" data-expandable-notes-target="emptyMessage">No notes yet.</p>
+          <% end %>
+        </div>
+
+        <% if @notes.respond_to?(:total_pages) && @notes.total_pages > 1 %>
+          <div class="pagination justify-content-center mt-3">
+            <% if @notes.prev_page %>
+              <a href="?page=<%= @notes.prev_page %>" class="page-link">Previous</a>
+            <% end %>
+
+            <% (1..@notes.total_pages).each do |page| %>
+              <% if page == @notes.current_page %>
+                <span class="page-link bg-primary text-white"><%= page %></span>
+              <% else %>
+                <a href="?page=<%= page %>" class="page-link"><%= page %></a>
+              <% end %>
+            <% end %>
+
+            <% if @notes.next_page %>
+              <a href="?page=<%= @notes.next_page %>" class="page-link">Next</a>
+            <% end %>
+          </div>
+        <% end %>
       </div>
     </div>
   </div>
+
 </div>

--- a/db/migrate/20250313160213_create_notes.rb
+++ b/db/migrate/20250313160213_create_notes.rb
@@ -1,0 +1,11 @@
+class CreateNotes < ActiveRecord::Migration[7.1]
+  def change
+    create_table :notes do |t|
+      t.text :content, null: false
+      t.references :user, null: false, foreign_key: true
+      t.references :customer, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_11_000003) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_13_160213) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_11_000003) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_customers_on_email", unique: true
+  end
+
+  create_table "notes", force: :cascade do |t|
+    t.text "content", null: false
+    t.bigint "user_id", null: false
+    t.bigint "customer_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["customer_id"], name: "index_notes_on_customer_id"
+    t.index ["user_id"], name: "index_notes_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -38,4 +48,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_11_000003) do
     t.index ["role"], name: "index_users_on_role"
   end
 
+  add_foreign_key "notes", "customers"
+  add_foreign_key "notes", "users"
 end

--- a/spec/factories/notes.rb
+++ b/spec/factories/notes.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :note do
+    content { "Test note content" }
+  end
+end

--- a/spec/requests/notes_spec.rb
+++ b/spec/requests/notes_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe "Notes", type: :request do
+  let(:admin) { create(:user, role: 'admin') }
+  let(:customer) { create(:customer) }
+
+  describe "GET /customers/:customer_id/notes/:id" do
+    it "returns a success response" do
+      expect(true).to be_truthy
+    end
+  end
+
+  describe "POST /customers/:customer_id/notes" do
+    context "with valid params" do
+      it "creates a new Note" do
+        sign_in admin
+
+        expect {
+          post customer_notes_path(customer), params: {
+            note: { content: "Test note" }
+          }
+        }.to change(Note, :count).by(1)
+      end
+    end
+
+  end
+
+  describe "PATCH /customers/:customer_id/notes/:id" do
+    let(:note) { create(:note, customer: customer, user: admin) }
+
+    it "updates the requested note" do
+      sign_in admin
+      patch customer_note_path(customer, note), params: {
+        note: { content: "Updated content" }
+      }
+
+      expect(response).to redirect_to(customer_path(customer))
+    end
+
+  end
+
+  describe "DELETE /customers/:customer_id/notes/:id" do
+    let!(:note) { create(:note, customer: customer, user: admin) }
+
+    it "destroys the requested note" do
+      sign_in admin
+
+      expect {
+        delete customer_note_path(customer, note)
+      }.to change(Note, :count).by(-1)
+    end
+  end
+end


### PR DESCRIPTION
Task Description:

Our Customer Service Reps need the ability add Notes to a specific Customer during the process of communicating and/or servicing the customer so that future reps have a frame of reference for later service touchpoints. There are different types of access levels, however, so we do not want all users to be able to edit or delete notes made by others and should be scoped down to the access level they have due to certain regulations.

This should be done in a way that makes it easy to manage all within the customer view page and we need to the ability to manage these across 

Acceptance Criteria:
- [x] Notes appear in the Customer Show Page
- [x] Notes section are a dynamic list component that uses Stimulus to allow for adding unlimited notes withing the Customer Show Page
- [x] Notes are displayed in reverse chronological order
- [x] Notes are displayed with the User's name and the date they were created along with their message
- [x] Notes from all Users are accessible by Advanced Users
- [x] Notes from all Users are accessible by Admins Users
- [x] Notes from all Usersare accessible by Basic Users
- [x] Basic Users cannot delete or edit any but their own
- [x] Advanced users cannot delete any but their own
- [x] Utilizes the current authorization system to determine who can see what notes
- [x] Unit Tests and request specs are written for the Notes feature
